### PR TITLE
Fix of the illustration link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 Looking for the best fashion for your [MSON AST](https://github.com/apiaryio/mson-ast)? Boutique offers the finest quality, luxury representations to emphasize natural beauty of your AST.
 
-![illustration](https://raw.github.com/apiaryio/boutique/master/assets/boutique.png)
+![illustration](https://github.com/apiaryio/boutique/blob/master/assets/boutique.png?raw=true)


### PR DESCRIPTION
Linking images within private repos is not trivial.

https://stackoverflow.com/questions/18937792/github-readme-image-embeds-in-private-repo
