### PR TITLE
Removing support for Node 0.8 as Apiary is already 0.10

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,16 +1,14 @@
+machine:
+  node:
+    version: "0.10"
+
 dependencies:
   override:
-    - nvm use v0.8
-    - npm install
-    - nvm use v0.10
     - npm install
 
 test:
   override:
-    - (coffee scripts/generate-samples-ast.coffee && git diff --exit-code ./test/formats/samples-ast/) || (echo "Test suite is not up to date!" && exit 1)
-    - coffee scripts/lint-json.coffee
-    - coffee scripts/lint-json-schema-v4.coffee
-    - nvm use v0.8
-    - npm test
-    - nvm use v0.10
+    - (./node_modules/coffee-script/bin/coffee scripts/generate-samples-ast.coffee && git diff --exit-code ./test/formats/samples-ast/) || (echo "Test suite is not up to date!" && exit 1)
+    - ./node_modules/coffee-script/bin/coffee scripts/lint-json.coffee
+    - ./node_modules/coffee-script/bin/coffee scripts/lint-json-schema-v4.coffee
     - npm test

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/apiaryio/boutique.git"
   },
   "engines": {
-    "node": ">= 0.8.x"
+    "node": ">= 0.10.x"
   },
   "scripts": {
     "test": "./node_modules/.bin/mocha --compilers coffee:coffee-script/register ./test ./test/formats"


### PR DESCRIPTION
Boutique was developed also for 0.8, because Apiary product app was 0.8. This is no longer needed, Apiary is 0.10 already. We don't need to check for anything else (and if, then rather for future versions).

Had to add `./node_modules/coffee-script/bin/coffee`, because without `nvm` simple `coffee` did not work.

Platfrom Support or @fosrias @smizell Please review and merge.
