### PR TITLE
Reset version number

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boutique",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "author": "Apiary.io <support@apiary.io>",
   "description": "The finest representations to emphasize natural beauty of your MSON AST",
   "repository" : {


### PR DESCRIPTION
No projects depend on Boutique yet, but [soon will](https://github.com/apiaryio/drafter), so I guess it's the right time to fix version number before it's too late. I just spotted it's not `0.0.1`, but `0.1.0` for some reason. Maybe in past I thought I reached that version number, but as Boutique was then rewritten from scratch, I think it's fair to reset the number, too.

Platfrom Support or @fosrias @smizell Please review and merge.
